### PR TITLE
Fix: footer stays at the bottom

### DIFF
--- a/site/pages/dashboard.js
+++ b/site/pages/dashboard.js
@@ -40,7 +40,7 @@ const Dashboard = () => {
 
     return (
         <>
-            <div>
+            <div className="flex flex-col min-h-screen">
                 <UserHeader/>
                 <main>
                     <section className='grid md:grid-cols-2 xl:grid-cols-4 gap-4 p-8'>


### PR DESCRIPTION
### Description
This PR fixes an issue where the footer was appearing in the middle of the page instead of staying at the bottom. The change ensures that the footer remains positioned at the bottom of the page, even when the content doesn't fill the full viewport. This maintains a cleaner design and improves the user experience.

### Related Issue
Fixes #86

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

![image](https://github.com/user-attachments/assets/0b3c5fb8-af62-4bd1-abaa-c9740eba0f8e)