### PR TITLE
Fix the overlapping of text in FAQ section all cards

### DIFF
--- a/site/components/Faq.js
+++ b/site/components/Faq.js
@@ -67,12 +67,12 @@ const Faq = () => {
             </div>
             <div
               className={`overflow-hidden transition-all duration-700 ease-in-out 
-                ${activeIndex === index ? 'max-h-[200px] opacity-100' : 'max-h-0 opacity-0'}`}
+                ${activeIndex === index ? 'max-h-[200px] opacity-100 ml-3' : 'max-h-0 opacity-0'}`}
               style={{ height: activeIndex === index ? 'auto' : '0px' }}
             >
               <p className="text-gray-600 leading-relaxed transition-opacity duration-500">{faq.answer}</p>
             </div>
-            <span className="text-sm text-gray-500 mt-2">{activeIndex === index ? 'Hide' : 'Show'} Answer</span>
+            <span className="text-sm text-gray-500 mt-2 ml-2">{activeIndex === index ? 'Hide' : 'Show'} Answer</span>
           </div>
         ))}
       </div>


### PR DESCRIPTION
### Description
 Fix the overlapping of text in FAQ cards.


https://github.com/user-attachments/assets/d8a1e56a-4f94-4a47-8293-23ce72f3fcb9



### Related Issue
Fixes #296 

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
